### PR TITLE
Day 5: Retrieval integrity, filters, empty-store UX, tests scaffolding

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,11 +1,11 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl, ConfigDict
 from typing import List, Optional, Literal
 
 class RetrieveFilters(BaseModel):
-    topics:   Optional[List[str]] = None
+    topics: Optional[List[str]] = None
     counties: Optional[List[str]] = None
-    date_from: Optional[str] = None  # YYYY-MM-DD
-    date_to:   Optional[str] = None
+    date_from: Optional[str] = None # YYYY-MM-DD (ISO)
+    date_to: Optional[str] = None # YYYY-MM-DD (ISO)
 
 class GenerateRequest(BaseModel):
     org_brief: str = Field(..., description="Short org boilerplate and capacity notes")
@@ -18,17 +18,41 @@ class GenerateRequest(BaseModel):
     k: int = 8
     filters: Optional[RetrieveFilters] = None
 
+class SourceItem(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+
+    # Accept both new ('marker') and legacy ('n') keys.
+    # Either is optional; downstream code can prefer 'marker' if present.
+    marker: Optional[int] = None       # new, 1-based marker number
+    n: Optional[int] = None            # legacy key
+    doc_id: str
+    title: str
+    url: Optional[HttpUrl] = None      # allow None for legacy/local PDFs
+    date: Optional[str] = Field(default=None, pattern=r"^\d{4}-\d{2}-\d{2}$")
+    county: Optional[str] = None
+    topics: Optional[List[str]] = None
+
 class EmailPiece(BaseModel):
     subjects: List[str]
     body_md: str
-    citations: List[dict]
+    citations: List[SourceItem]
 
 class NarrativePiece(BaseModel):
     body_md: str
-    citations: List[dict]
+    citations: List[SourceItem]
 
 class GenerateEmailResponse(BaseModel):
     email: EmailPiece
 
 class GenerateNarrativeResponse(BaseModel):
     narrative: NarrativePiece
+
+class GenerateEmailResponseCompat(GenerateEmailResponse):
+    # legacy keys for old UI; included in schema so FastAPI won't drop them
+    email_md: Optional[str] = None
+    email_sources: Optional[List[SourceItem]] = None
+
+class GenerateNarrativeResponseCompat(GenerateNarrativeResponse):
+    # legacy keys for old UI
+    narrative_md: Optional[str] = None
+    narrative_sources: Optional[List[SourceItem]] = None

--- a/app/routes/generate.py
+++ b/app/routes/generate.py
@@ -1,59 +1,137 @@
+# app/routes/generate.py
+
 from fastapi import APIRouter
-from app.models.schemas import GenerateRequest, GenerateEmailResponse, GenerateNarrativeResponse
-from app.services.retriever import retrieve
-from app.services.generator import generate_email, generate_narrative
-from app.services.citations import build_sources
+from typing import List, Dict, Any, Optional
 import os
 
+from app.models.schemas import (
+    GenerateRequest,
+    SourceItem,
+    EmailPiece,
+    NarrativePiece,
+    GenerateEmailResponseCompat,
+    GenerateNarrativeResponseCompat,
+)
+from app.services.retriever import retrieve
+from app.services.generator import generate_email, generate_narrative
+
+# If app/main.py already mounts this with prefix="/generate",
+# keep router = APIRouter(). Otherwise you can set: APIRouter(prefix="/generate", tags=["generate"])
 router = APIRouter()
+
 KB_PATH = os.environ.get("KB_PATH", "data/processed")
 
-@router.post("/email")
+
+import re, logging, hashlib
+logger = logging.getLogger(__name__)
+
+def _map_citations(raw_list):
+    norm = []
+    for s in (raw_list or []):
+        d = dict(s)  # shallow copy
+
+        # title: accept 'label' fallback
+        if not d.get("title"):
+            d["title"] = d.get("label") or "Source"
+
+        # marker: accept legacy 'n'
+        if d.get("n") is not None and d.get("marker") is None:
+            d["marker"] = d["n"]
+
+        # url: empty string → None for Optional[HttpUrl]
+        url = (d.get("url") or "").strip()
+        d["url"] = url or None
+
+        # date: must be YYYY-MM-DD or None
+        dv = d.get("date")
+        if not dv or not re.match(r"^\d{4}-\d{2}-\d{2}$", str(dv)):
+            d["date"] = None
+
+        # topics: normalize to list[str]
+        tv = d.get("topics")
+        if tv is None:
+            d["topics"] = []
+        elif not isinstance(tv, list):
+            d["topics"] = [str(tv)]
+        else:
+            d["topics"] = [str(x) for x in tv if str(x).strip()]
+
+        # ---- ensure doc_id (required) ----
+        if not d.get("doc_id"):
+            if url:
+                d["doc_id"] = f"url::{url}"
+            else:
+                # stable-ish fallback from title (+ marker if present)
+                seed = (d.get("title") or "") + "|" + str(d.get("marker") or "")
+                d["doc_id"] = "doc::" + hashlib.sha1(seed.encode("utf-8")).hexdigest()[:12]
+
+        try:
+            norm.append(SourceItem(**d))
+        except Exception:
+            logger.exception("Bad citation payload after normalization: %r", d)
+            # Skip malformed entries instead of 500-ing the whole response
+    return norm
+
+@router.post("/email", response_model=GenerateEmailResponseCompat)
 def post_generate_email(req: GenerateRequest):
     query = f"{req.campaign_brief}\n{req.org_brief}"
     filters = req.filters.model_dump(exclude_none=True) if req.filters else None
+
     try:
         ctx = retrieve(query=query, kb_path=KB_PATH, k=req.k, filters=filters)
     except FileNotFoundError:
-        # Empty-store friendly response that still conforms to your response_model
-        return {"email": {"subjects": [], "body_md": "", "citations": []}}
+        # Empty-store friendly: return BOTH typed object and legacy keys.
+        empty_email = EmailPiece(subjects=[], body_md="", citations=[])
+        return {
+            "email": empty_email,
+            "email_md": empty_email.body_md,         # legacy
+            "email_sources": [],                     # legacy
+        }
 
-    # Build deduped, ordered sources from retrieved chunks
-    _, sources = build_sources(ctx)
-    email = generate_email(payload=req.model_dump(), ctx=ctx)
+    # Let the generator do grounding + markers + finalization
+    out = generate_email(payload=req.model_dump(), ctx=ctx)
 
-    # Ensure grounded citations go back to the UI
-    email["citations"] = sources
+    # Construct the typed piece
+    email = EmailPiece(
+        subjects=out.get("subjects", []),
+        body_md=out.get("body_md", out.get("email_md", "")),
+        citations=_map_citations(out.get("citations")),
+    )
 
-    # Return flat keys expected by the UI
+    # Return typed + legacy keys
     return {
-        "email_md": email.get("body_md", ""),
-        "email_sources": email.get("citations", []),
-        "subjects": email.get("subjects", []),
-        # (optional) include these only if your UI reads them; otherwise omit:
-        # "k": req.k,
-        # "applied_filters": filters or {},
-        # "chunks": ctx,
+        "email": email,
+        "email_md": email.body_md,                              # legacy
+        "email_sources": [c.model_dump() for c in email.citations],  # legacy
+        # NOTE: We intentionally do NOT return top-level "subjects" anymore.
+        # The UI should read subjects from resp["email"]["subjects"].
     }
 
-@router.post("/narrative")
-def post_generate_narrative(req: GenerateRequest):      
+
+@router.post("/narrative", response_model=GenerateNarrativeResponseCompat)
+def post_generate_narrative(req: GenerateRequest):
     query = f"{req.campaign_brief}\n{req.org_brief}"
     filters = req.filters.model_dump(exclude_none=True) if req.filters else None
+
     try:
         ctx = retrieve(query=query, kb_path=KB_PATH, k=req.k, filters=filters)
     except FileNotFoundError:
-        return {"narrative": {"body_md": "", "citations": []}}
+        empty_narr = NarrativePiece(body_md="", citations=[])
+        return {
+            "narrative": empty_narr,
+            "narrative_md": empty_narr.body_md,     # legacy
+            "narrative_sources": [],                # legacy
+        }
 
-    _, sources = build_sources(ctx)
-    narrative = generate_narrative(payload=req.model_dump(), ctx=ctx)
-    narrative["citations"] = sources
+    out = generate_narrative(payload=req.model_dump(), ctx=ctx)
+
+    narrative = NarrativePiece(
+        body_md=out.get("body_md", out.get("narrative_md", "")),
+        citations=_map_citations(out.get("citations")),
+    )
 
     return {
-        "narrative_md": narrative.get("body_md", ""),
-        "narrative_sources": narrative.get("citations", []),
-        # (optional) only if your UI reads them:
-        # "k": req.k,
-        # "applied_filters": filters or {},
-        # "chunks": ctx,
+        "narrative": narrative,
+        "narrative_md": narrative.body_md,                         # legacy
+        "narrative_sources": [c.model_dump() for c in narrative.citations],  # legacy
     }

--- a/app/services/postprocess.py
+++ b/app/services/postprocess.py
@@ -1,0 +1,56 @@
+import re
+from typing import List, Dict, Tuple
+
+MARKER_RE = re.compile(r"\[(\d+)\]")
+
+def _strip_model_sources_section(md: str) -> str:
+    # Drop any trailing "Sources:" section the model may have added on its own.
+    return re.sub(r"\n+#+?\s*Sources?:.*\Z", "", md, flags=re.IGNORECASE | re.DOTALL)
+
+def rebuild_sources_in_marker_order(body_md: str, sources: List[Dict]) -> Tuple[str, List[Dict]]:
+    body_md = _strip_model_sources_section(body_md)
+
+    # Collect the order in which markers appear (first occurrence wins)
+    used = [int(n) for n in MARKER_RE.findall(body_md)]
+    order, seen = [], set()
+    for n in used:
+        if n not in seen:
+            order.append(n); seen.add(n)
+
+    # Reorder sources to match first-use order and renumber sequentially from 1..m
+    by_n = {s.get("n"): s for s in sources}
+    new_sources = []
+    for i, old_n in enumerate(order, start=1):
+        s = by_n.get(old_n)
+        if s:
+            s2 = {**s, "n": i}
+            new_sources.append(s2)
+
+    # Rewrite [old] -> [new] in the body
+    def _renumber(m):
+        old = int(m.group(1))
+        new = order.index(old) + 1 if old in order else old
+        return f"[{new}]"
+
+    body_md = MARKER_RE.sub(_renumber, body_md)
+    return body_md, new_sources
+
+def sanitize_on_no_sources(body_md: str, sources: List[Dict]) -> Tuple[str, List[Dict]]:
+    """
+    If there are no sources, strip any stray [n] markers and any trailing 'Sources/References' section.
+    """
+    if sources and len(sources) > 0:
+        return body_md, sources
+
+    # remove bracket citations like [1], [12] (including optional leading whitespace)
+    body_md = re.sub(r"\s*\[\d+\]", "", body_md)
+
+    # remove a trailing Sources/References section (Markdown headers or plain)
+    body_md = re.sub(
+        r"\n+#{0,2}\s*(Sources|References)\s*:?.*$",
+        "",
+        body_md,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+
+    return body_md, []

--- a/scripts/eval_retrieval.py
+++ b/scripts/eval_retrieval.py
@@ -23,14 +23,18 @@ def main():
 
     chunks = rtr.retrieve(args.query, k=args.k, filters=filters)
     print(f"Top-{args.k} for: {args.query}")
-    for i, ch in enumerate(chunks, 1):
-        title = (ch.get('title')
-                 or ch.get('meta', {}).get('title')
-                 or 'Source')
-        url = (ch.get('url')
-               or ch.get('meta', {}).get('url')
-               or '')
-        print(f"{i:>2}. {title}  —  {url}")
+    seen = set()
+    rank = 1
+    for ch in chunks:
+        doc_id = ch.get("doc_id") or f"{ch.get('source','')}|{ch.get('title','Source')}"
+        if doc_id in seen:
+            continue
+        seen.add(doc_id)
+        title = ch.get("title") or "Source"
+        url = ch.get("source") or ""
+        print(f"{rank:>2}. {title}  —  {url}")
+        rank += 1
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -8,6 +8,8 @@ import numpy as np
 from dotenv import load_dotenv, dotenv_values
 from openai import OpenAI
 
+import hashlib
+
 # Optional deps (graceful if missing)
 try:
     import fitz  # PyMuPDF
@@ -210,6 +212,9 @@ def main():
     ap.add_argument("--max-doc-chars", type=int, default=DEFAULT_MAX_DOC_CHARS, help="Max chars per doc after cleaning")
 
     args = ap.parse_args()
+    iso_date = args.date or None
+    county = args.county or None
+    topics = args.topic or []
 
     if not API_KEY:
         raise SystemExit("OPENAI_API_KEY not found. Put it in .env or environment.")
@@ -231,9 +236,9 @@ def main():
             "id": f"pdf::{path.name}",
             "title": path.stem,
             "url": file_uri(path),
-            "date": args.date,
-            "county": args.county,
-            "topics": args.topic,
+            "date": iso_date,
+            "county": county,
+            "topics": topics,
             "text": text,
             "source_type": "pdf",
         })
@@ -250,9 +255,9 @@ def main():
             "id": f"docx::{path.name}",
             "title": path.stem,
             "url": file_uri(path),
-            "date": args.date,
-            "county": args.county,
-            "topics": args.topic,
+            "date": iso_date,
+            "county": county,
+            "topics": topics,
             "text": text,
             "source_type": "docx",
         })
@@ -266,13 +271,14 @@ def main():
         except Exception as e:
             print(f"[WARN] fetch failed for {u}: {e}")
             continue
+        doc_id = "doc::" + hashlib.sha1(u.encode()).hexdigest()[:10]
         documents.append({
-            "id": f"url::{u}",
+            "id": doc_id,
             "title": obj["title"],
             "url": u,
-            "date": args.date,
-            "county": args.county,
-            "topics": args.topic,
+            "date": iso_date,
+            "county": county,
+            "topics": topics,
             "text": obj["text"],
             "source_type": "url",
         })

--- a/tests/day5_e2e.ps1
+++ b/tests/day5_e2e.ps1
@@ -1,0 +1,104 @@
+param([string]$Api = "http://127.0.0.1:8000")
+
+$ErrorActionPreference = "Stop"
+$RequestDelayMs = 300  # raise to 450 if needed
+
+function Assert($cond, $msg) {
+  if (-not $cond) {
+    Write-Host "FAIL: $msg" -ForegroundColor Red
+    exit 1
+  } else {
+    Write-Host "OK:   $msg" -ForegroundColor Green
+  }
+}
+
+function Post($route, $obj) {
+  $json = $obj | ConvertTo-Json -Depth 8
+  $res = Invoke-RestMethod -Method POST -Uri ($Api + $route) -ContentType "application/json" -DisableKeepAlive -Body $json
+  Start-Sleep -Milliseconds $RequestDelayMs
+  return $res
+}
+
+# === A) Ingestion (skip if chunks already exist) ===
+Write-Host "`n=== A) Ingestion ==="
+$chunksPath = "data/processed/chunks.jsonl"
+if (-not (Test-Path $chunksPath)) {
+  python scripts/ingest.py --url "https://www.sba.gov/funding-programs/disaster-assistance" --url "https://www.ncdps.gov/our-organization/emergency-management/disaster-recovery/public-assistance" --url "https://www.commerce.nc.gov/guidelines-project-descriptions-round-1-small-business-infrastructure-grant-program-smbiz/download?attachment=" --county "Haywood" --topic "small_business" --date "2025-02-05" --outdir "data/processed"
+} else {
+  Write-Host "INFO: chunks already exist at data/processed/chunks.jsonl — skipping re-ingest."
+}
+
+Assert (Test-Path "data/processed") "processed folder exists"
+
+if (-not (Test-Path $chunksPath)) {
+  $candidate = Get-ChildItem "data/processed" -Filter *.jsonl -File -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($candidate) { $chunksPath = $candidate.FullName }
+}
+Assert (Test-Path $chunksPath) "chunks JSONL file exists: $chunksPath"
+
+$first = Get-Content $chunksPath -TotalCount 1 | ConvertFrom-Json
+Assert ($null -ne $first.doc_id -and $first.doc_id -ne "") "doc_id present"
+Assert ($first.date -match "^\d{4}-\d{2}-\d{2}$") "date is ISO-like (YYYY-MM-DD)"
+Assert ($first.PSObject.Properties.Name -contains "url") "url field present (may be null)"
+
+# === B) Retrieval ===
+Write-Host "`n=== B) Retrieval ==="
+$res = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{}; k = 6 }
+Assert ($null -ne $res.email_md -and $res.email_md.Length -gt 0) "email_md returned"
+Assert ((($res.email_sources) | Measure-Object).Count -ge 0) "legacy email_sources present"
+
+$res = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{ date_from = "2024-09-01"; date_to = "2025-12-31" }; k = 6 }
+Assert ($null -ne $res.email_md -and $res.email_md.Length -gt 0) "filtered email_md returned"
+Assert ((($res.email_sources) | Measure-Object).Count -ge 0) "filtered citations ok"
+
+foreach ($k in 3, 12) {
+  $r = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{}; k = $k }
+  Assert ($null -ne $r) "k=$k returned 200"
+  $c = (($r.email_sources) | Measure-Object).Count
+  Write-Host ("k={0} -> {1} sources" -f $k, $c)
+}
+
+$r = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{ date_from = "2015-01-01"; date_to = "2015-12-31" }; k = 6 }
+$noMarkers = -not ($r.email_md -match "\[\d+\]")
+$srcCount = (($r.email_sources) | Measure-Object).Count
+Assert $noMarkers "no markers on no-match"
+Assert ($srcCount -eq 0) "no citations on no-match"
+
+# === C) Post-process ===
+Write-Host "`n=== C) Post-process ==="
+$r = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{}; k = 6 }
+$psCount = ([regex]::Matches($r.email_md, "(?m)^P\.S\.:")).Count
+Assert ($psCount -eq 1) "P.S. appears once"
+$markerCount = ([regex]::Matches($r.email_md, "\[(\d+)\]")).Count
+$sourceCount = (($r.email_sources) | Measure-Object).Count
+Assert ($markerCount -eq $sourceCount) "marker count matches sources count"
+if ($r.email -and $r.email.subject_lines) {
+  Assert ($r.email.subject_lines.Count -eq 3) "3 subject lines"
+} else {
+  Write-Host "INFO: typed email.subject_lines not present; skipping subject line count check."
+}
+
+# === D) Routes ===
+Write-Host "`n=== D) Routes ==="
+$rE = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{} }
+$rN = Post "/generate/narrative" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{} }
+Assert ($rE.PSObject.Properties.Name -contains "email_md") "legacy email_md present"
+Assert ($rE.PSObject.Properties.Name -contains "email_sources") "legacy email_sources present"
+if ($rE.email) { Write-Host "INFO: typed email present" }
+if ($rN.narrative) { Write-Host "INFO: typed narrative present" }
+
+# === G) Resilience ===
+Write-Host "`n=== G) Resilience ==="
+$r = Post "/generate/email" @{ org_brief = "Asheville Relief Fund"; retrieve_filters = @{} }
+Assert ($null -ne $r) "200 with missing optional fields"
+
+# === H) Health ===
+Write-Host "`n=== H) Health ==="
+$root = Invoke-RestMethod -Uri ($Api + "/") -DisableKeepAlive
+Start-Sleep -Milliseconds $RequestDelayMs
+$oa   = Invoke-RestMethod -Uri ($Api + "/openapi.json") -DisableKeepAlive
+Start-Sleep -Milliseconds $RequestDelayMs
+Assert ($null -ne $root) "/ returns 200"
+Assert ($oa.info.title) "OpenAPI returns info"
+
+Write-Host "`nAll scripted checks passed (E and F are manual in UI)."

--- a/tests/day5_e2e_min.ps1
+++ b/tests/day5_e2e_min.ps1
@@ -1,0 +1,111 @@
+param([string]$Api = "http://127.0.0.1:8000")
+
+$ErrorActionPreference = "Stop"
+$RequestDelayMs = 300
+
+function Assert($cond, $msg) {
+  if (-not $cond) { Write-Host "FAIL: $msg" -ForegroundColor Red; exit 1 }
+  Write-Host "OK:   $msg" -ForegroundColor Green
+}
+
+# Build a request body compatible with either schema (campaign_brief new, org_brief legacy)
+function BuildReq($filters, $k=6) {
+  return @{
+    campaign_brief  = "Asheville Relief Fund is a 501(c)(3) supporting WNC small-business recovery."
+    org_brief       = "Asheville Relief Fund is a 501(c)(3) supporting WNC small-business recovery."
+    retrieve_filters = $filters
+    k = $k
+  }
+}
+
+function Post($route, $obj) {
+  $json = $obj | ConvertTo-Json -Depth 8
+  $res = Invoke-RestMethod -Method POST -Uri ($Api + $route) -ContentType "application/json" -DisableKeepAlive -Body $json
+  Start-Sleep -Milliseconds $RequestDelayMs
+  return $res
+}
+
+Write-Host ""
+Write-Host "=== A) Ingestion (skips if chunks exist) ==="
+$chunksPath = "data/processed/chunks.jsonl"
+
+if (-not (Test-Path $chunksPath)) {
+  python scripts/ingest.py --url "https://www.sba.gov/funding-programs/disaster-assistance" --url "https://www.ncdps.gov/our-organization/emergency-management/disaster-recovery/public-assistance" --url "https://www.commerce.nc.gov/guidelines-project-descriptions-round-1-small-business-infrastructure-grant-program-smbiz/download?attachment=" --county "Haywood" --topic "small_business" --date "2025-02-05" --outdir "data/processed"
+}
+if (Test-Path $chunksPath) { Write-Host "INFO: using existing chunks at data/processed/chunks.jsonl" }
+
+Assert (Test-Path "data/processed") "processed folder exists"
+
+if (-not (Test-Path $chunksPath)) {
+  $candidate = Get-ChildItem "data/processed" -Filter *.jsonl -File -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($candidate) { $chunksPath = $candidate.FullName }
+}
+Assert (Test-Path $chunksPath) "chunks JSONL file exists: $chunksPath"
+
+$first = Get-Content $chunksPath -TotalCount 1 | ConvertFrom-Json
+Assert ($null -ne $first.doc_id -and $first.doc_id -ne "") "doc_id present"
+Assert ($first.date -match "^\d{4}-\d{2}-\d{2}$") "date is ISO-like"
+Assert ($first.PSObject.Properties.Name -contains "url") "url field present"
+
+Write-Host ""
+Write-Host "=== B) Retrieval ==="
+$res = Post "/generate/email" (BuildReq @{} 6)
+Assert ($null -ne $res.email_md -and $res.email_md.Length -gt 0) "email_md returned"
+Assert ((($res.email_sources) | Measure-Object).Count -ge 0) "legacy email_sources present"
+
+$res = Post "/generate/email" (BuildReq @{ date_from = "2024-09-01"; date_to = "2025-12-31" } 6)
+Assert ($null -ne $res.email_md -and $res.email_md.Length -gt 0) "filtered email_md returned"
+Assert ((($res.email_sources) | Measure-Object).Count -ge 0) "filtered citations ok"
+
+foreach ($k in 3, 12) {
+  $r = Post "/generate/email" (BuildReq @{} $k)
+  Assert ($null -ne $r) ("k=" + $k + " returned 200")
+  $c = (($r.email_sources) | Measure-Object).Count
+  Write-Host ("k=" + $k + " -> " + $c + " sources")
+}
+
+$r = Post "/generate/email" (BuildReq @{ date_from = "2015-01-01"; date_to = "2015-12-31" } 6)
+$noMarkers = -not ($r.email_md -match "\[\d+\]")
+$srcCount = (($r.email_sources) | Measure-Object).Count
+Assert $noMarkers "no markers on no-match"
+Assert ($srcCount -eq 0) "no citations on no-match"
+
+Write-Host ""
+Write-Host "=== C) Post-process ==="
+$r = Post "/generate/email" (BuildReq @{} 6)
+$psCount = ([regex]::Matches($r.email_md, "(?m)^P\.S\.:")).Count
+Assert ($psCount -eq 1) "P.S. appears once"
+$markerCount = ([regex]::Matches($r.email_md, "\[(\d+)\]")).Count
+$sourceCount = (($r.email_sources) | Measure-Object).Count
+Assert ($markerCount -eq $sourceCount) "marker count matches sources count"
+if ($r.email -and $r.email.subject_lines) {
+  Assert ($r.email.subject_lines.Count -eq 3) "3 subject lines"
+} else {
+  Write-Host "INFO: typed email.subject_lines not present; skipping."
+}
+
+Write-Host ""
+Write-Host "=== D) Routes ==="
+$rE = Post "/generate/email" (BuildReq @{} 6)
+$rN = Post "/generate/narrative" (BuildReq @{} 6)
+Assert ($rE.PSObject.Properties.Name -contains "email_md") "legacy email_md present"
+Assert ($rE.PSObject.Properties.Name -contains "email_sources") "legacy email_sources present"
+if ($rE.email) { Write-Host "INFO: typed email present" }
+if ($rN.narrative) { Write-Host "INFO: typed narrative present" }
+
+Write-Host ""
+Write-Host "=== G) Resilience ==="
+$r = Post "/generate/email" (BuildReq @{} 6)
+Assert ($null -ne $r) "200 with missing optional fields"
+
+Write-Host ""
+Write-Host "=== H) Health ==="
+$root = Invoke-RestMethod -Uri ($Api + "/") -DisableKeepAlive
+Start-Sleep -Milliseconds $RequestDelayMs
+$oa = Invoke-RestMethod -Uri ($Api + "/openapi.json") -DisableKeepAlive
+Start-Sleep -Milliseconds $RequestDelayMs
+Assert ($null -ne $root) "/ returns 200"
+Assert ($oa.info.title) "OpenAPI returns info"
+
+Write-Host ""
+Write-Host "All scripted checks passed (E and F are manual in UI)."


### PR DESCRIPTION

## Summary
Implements Day 5 workstreams; compatible with Day 4 code. API health/tests can be finalized in a follow-up.

## Changes
- Multi-source grounding; k≥12; adjacent dedupe by doc_id (flat hits)
- Marker↔footnote integrity: single finalizer pass
- Filters: normalized once at route; retriever backstop retained
- Schemas: Optional[HttpUrl], ISO date regex
- Friendly empty-store response (no_context)
- /health + test scaffolding (pytest not yet wired locally)
- UI: filter pills + subject polish

## Acceptance Checks (current status)
- [ ] Bodies show [1][2]…; ≥2 unique sources; no adjacent dupes
- [ ] Markers set ≡ footnotes set; contiguous numbering
- [ ] Filters pills reflect active filters; toggling predictable
- [ ] Empty index → no_context JSON; UI notice
- [ ] pytest -q passes locally
- [ ] Sources include doc_id, title, url, date, county, topics (ISO dates; clean URLs)

## Notes
- wnc-check failed because the API wasn’t running; will address in next commit.
- pytest not installed in venv; will add in follow-up (pip install pytest).
